### PR TITLE
bump to golang 1.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GINKGO ?= $(LOCALBIN)/ginkgo
 
 ## Tool Versions
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
-GOTOOLCHAIN_VERSION ?= go1.21.0
+GOTOOLCHAIN_VERSION ?= go1.22.0
 GOLANGCI_VERSION ?= v1.64.8
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.

--- a/modules/ansible/go.mod
+++ b/modules/ansible/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/lib-common/modules/ansible
 
-go 1.21
+go 1.22
 
 require gopkg.in/yaml.v3 v3.0.1
 

--- a/modules/certmanager/go.mod
+++ b/modules/certmanager/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/lib-common/modules/certmanager
 
-go 1.21
+go 1.22
 
 require (
 	github.com/cert-manager/cert-manager v1.11.5

--- a/modules/common/go.mod
+++ b/modules/common/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/lib-common/modules/common
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/modules/openstack/go.mod
+++ b/modules/openstack/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/lib-common/modules/openstack
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/modules/storage/go.mod
+++ b/modules/storage/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/lib-common/modules/storage
 
-go 1.21
+go 1.22
 
 require github.com/onsi/gomega v1.34.1
 

--- a/modules/test/go.mod
+++ b/modules/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/lib-common/modules/test
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
* bump in go.mod

Jira: OSPRH-12935

## Summary by Sourcery

Chores:
- Update Go version from 1.21 to 1.22 in Makefile and all module go.mod files